### PR TITLE
Update for /tmp/ directory

### DIFF
--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -48,8 +48,8 @@ TARGET_BRANCH=${GITHUB_BASE_REF:-main}
 COVERAGE_ARTIFACT_NAME=${COVERAGE_ARTIFACT_NAME:-code-coverage}
 COVERAGE_FILE_NAME=${COVERAGE_FILE_NAME:-coverage.txt}
 
-OLD_COVERAGE_PATH=.github/outputs/old_coverage/old-coverage.txt
-NEW_COVERAGE_PATH=.github/outputs/new_coverage/new-coverage.txt
+OLD_COVERAGE_PATH=.github/outputs/old-coverage.txt
+NEW_COVERAGE_PATH=.github/outputs/new-coverage.txt
 COVERAGE_COMMENT_PATH=.github/outputs/coverage-comment.md
 CHANGED_FILES_PATH=${CHANGED_FILES_PATH:-.github/outputs/all_changed_files.json}
 

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -80,7 +80,6 @@ end_group(){
 
 start_group "Download code coverage results from current run"
 gh run download "$GITHUB_RUN_ID" --name="$COVERAGE_ARTIFACT_NAME" --dir="/tmp/gh-run-download-$GITHUB_RUN_ID"
-ls /tmp/gh-run-download-$GITHUB_RUN_ID
 mv "/tmp/gh-run-download-$GITHUB_RUN_ID/$COVERAGE_FILE_NAME" $NEW_COVERAGE_PATH
 rm -r "/tmp/gh-run-download-$GITHUB_RUN_ID"
 end_group

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -80,6 +80,7 @@ end_group(){
 
 start_group "Download code coverage results from current run"
 gh run download "$GITHUB_RUN_ID" --name="$COVERAGE_ARTIFACT_NAME" --dir="/tmp/gh-run-download-$GITHUB_RUN_ID"
+ls /tmp/gh-run-download-$GITHUB_RUN_ID
 mv "/tmp/gh-run-download-$GITHUB_RUN_ID/$COVERAGE_FILE_NAME" $NEW_COVERAGE_PATH
 rm -r "/tmp/gh-run-download-$GITHUB_RUN_ID"
 end_group


### PR DESCRIPTION
Updates needed as main repository handled extra artifact conflicts with temp directories:
https://github.com/fgrosse/go-coverage-report/pull/30

This removes the now unnnecessary `old_coverage` and `new_coverage` paths.