### PR TITLE
Init: Add support for specifying main coverage artifact

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,12 @@ inputs:
     description: "The Github Run ID of the target branch to compare coverage against"
     required: false
 
+  main-coverage-artifact-name:
+    description: |
+      The artifact name associated with the main coverage file. This is intended to be used when running
+      generating coverage for main and the PR in the same pipeline.
+    required: false
+
   root-package:
     description: |
       The Go import path of the tested repository to add as a prefix to all paths of the
@@ -76,6 +82,7 @@ runs:
         GITHUB_BASE_REF: ${{ github.base_ref }}
         CHANGED_FILES_PATH: .github/outputs/all_changed_files.json
         COVERAGE_ARTIFACT_NAME: ${{ inputs.coverage-artifact-name }}
+        MAIN_COVERAGE_ARTIFACT_NAME: ${{ inputs.main-coverage-artifact-name }}
         LAST_SUCCESSFUL_RUN_ID: ${{ inputs.target-run-id }}
         COVERAGE_FILE_NAME: ${{ inputs.coverage-file-name }}
         ROOT_PACKAGE: ${{ inputs.root-package }}

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -85,21 +85,21 @@ rm -r "/tmp/gh-run-download-$GITHUB_RUN_ID"
 end_group
 
 start_group "Download code coverage results from target branch"
-# Check if LAST_SUCCESSFUL_RUN_ID is already set
-if [ -z "$LAST_SUCCESSFUL_RUN_ID" ]; then
-  echo "Fetching default target branch run ID"
-  LAST_SUCCESSFUL_RUN_ID=$(gh run list --status=success --branch="$TARGET_BRANCH" --workflow="$GITHUB_WORKFLOW" --event=push --json=databaseId --limit=1 -q '.[] | .databaseId')
-  if [ -z "$LAST_SUCCESSFUL_RUN_ID" ]; then
-    echo "::error::No successful run found on the target branch"
-    exit 1
-  fi
-else
+
+# Fetch artifact from provided run ID for comparison
+if [ -n "$LAST_SUCCESSFUL_RUN_ID" ]; then
   echo "Using provided target-run-id: $LAST_SUCCESSFUL_RUN_ID"
+  gh run download "$LAST_SUCCESSFUL_RUN_ID" --name="$COVERAGE_ARTIFACT_NAME" --dir="/tmp/gh-run-download-$LAST_SUCCESSFUL_RUN_ID"
+  mv "/tmp/gh-run-download-$LAST_SUCCESSFUL_RUN_ID/$COVERAGE_FILE_NAME" $OLD_COVERAGE_PATH
+  rm -r "/tmp/gh-run-download-$LAST_SUCCESSFUL_RUN_ID"
 fi
 
-gh run download "$LAST_SUCCESSFUL_RUN_ID" --name="$COVERAGE_ARTIFACT_NAME" --dir="/tmp/gh-run-download-$LAST_SUCCESSFUL_RUN_ID"
-mv "/tmp/gh-run-download-$LAST_SUCCESSFUL_RUN_ID/$COVERAGE_FILE_NAME" $OLD_COVERAGE_PATH
-rm -r "/tmp/gh-run-download-$LAST_SUCCESSFUL_RUN_ID"
+# Use provided artifact name from current run for comparison
+if [ -n "$MAIN_COVERAGE_ARTIFACT_NAME" ]; then
+  echo "Using main coverage artifact name from $GITHUB_RUN_ID"
+  gh run download "$GITHUB_RUN_ID" --name="$MAIN_COVERAGE_ARTIFACT_NAME" --dir="/tmp/gh-run-download-$GITHUB_RUN_ID"
+  mv "/tmp/gh-run-download-$GITHUB_RUN_ID/$COVERAGE_FILE_NAME" $OLD_COVERAGE_PATH
+  rm -r "/tmp/gh-run-download-$GITHUB_RUN_ID"
 end_group
 
 start_group "Compare code coverage results"

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -96,8 +96,8 @@ fi
 # Use provided artifact name from current run for comparison
 if [ -n "$MAIN_COVERAGE_ARTIFACT_NAME" ]; then
   echo "Using main coverage artifact name from $GITHUB_RUN_ID"
-  ls /tmp/gh-run-download-9504432699
   gh run download "$GITHUB_RUN_ID" --name="$MAIN_COVERAGE_ARTIFACT_NAME" --dir="/tmp/gh-run-download-$GITHUB_RUN_ID"
+  ls /tmp/gh-run-download-9504432699
   mv "/tmp/gh-run-download-$GITHUB_RUN_ID/$COVERAGE_FILE_NAME" $OLD_COVERAGE_PATH
   rm -r "/tmp/gh-run-download-$GITHUB_RUN_ID"
 fi

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -96,6 +96,7 @@ fi
 # Use provided artifact name from current run for comparison
 if [ -n "$MAIN_COVERAGE_ARTIFACT_NAME" ]; then
   echo "Using main coverage artifact name from $GITHUB_RUN_ID"
+  ls /tmp/gh-run-download-9504432699
   gh run download "$GITHUB_RUN_ID" --name="$MAIN_COVERAGE_ARTIFACT_NAME" --dir="/tmp/gh-run-download-$GITHUB_RUN_ID"
   mv "/tmp/gh-run-download-$GITHUB_RUN_ID/$COVERAGE_FILE_NAME" $OLD_COVERAGE_PATH
   rm -r "/tmp/gh-run-download-$GITHUB_RUN_ID"

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -85,7 +85,6 @@ rm -r "/tmp/gh-run-download-$GITHUB_RUN_ID"
 end_group
 
 start_group "Download code coverage results from target branch"
-
 # Fetch artifact from provided run ID for comparison
 if [ -n "$LAST_SUCCESSFUL_RUN_ID" ]; then
   echo "Using provided target-run-id: $LAST_SUCCESSFUL_RUN_ID"
@@ -100,6 +99,7 @@ if [ -n "$MAIN_COVERAGE_ARTIFACT_NAME" ]; then
   gh run download "$GITHUB_RUN_ID" --name="$MAIN_COVERAGE_ARTIFACT_NAME" --dir="/tmp/gh-run-download-$GITHUB_RUN_ID"
   mv "/tmp/gh-run-download-$GITHUB_RUN_ID/$COVERAGE_FILE_NAME" $OLD_COVERAGE_PATH
   rm -r "/tmp/gh-run-download-$GITHUB_RUN_ID"
+fi
 end_group
 
 start_group "Compare code coverage results"

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -48,8 +48,8 @@ TARGET_BRANCH=${GITHUB_BASE_REF:-main}
 COVERAGE_ARTIFACT_NAME=${COVERAGE_ARTIFACT_NAME:-code-coverage}
 COVERAGE_FILE_NAME=${COVERAGE_FILE_NAME:-coverage.txt}
 
-OLD_COVERAGE_PATH=.github/outputs/old_coverage/old-coverage.txt
-NEW_COVERAGE_PATH=.github/outputs/new_coverage/new-coverage.txt
+OLD_COVERAGE_PATH=.github/outputs/old-coverage.txt
+NEW_COVERAGE_PATH=.github/outputs/new-coverage.txt
 COVERAGE_COMMENT_PATH=.github/outputs/coverage-comment.md
 CHANGED_FILES_PATH=${CHANGED_FILES_PATH:-.github/outputs/all_changed_files.json}
 

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -97,7 +97,6 @@ fi
 if [ -n "$MAIN_COVERAGE_ARTIFACT_NAME" ]; then
   echo "Using main coverage artifact name from $GITHUB_RUN_ID"
   gh run download "$GITHUB_RUN_ID" --name="$MAIN_COVERAGE_ARTIFACT_NAME" --dir="/tmp/gh-run-download-$GITHUB_RUN_ID"
-  ls /tmp/gh-run-download-9504432699
   mv "/tmp/gh-run-download-$GITHUB_RUN_ID/$COVERAGE_FILE_NAME" $OLD_COVERAGE_PATH
   rm -r "/tmp/gh-run-download-$GITHUB_RUN_ID"
 fi

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -80,7 +80,6 @@ end_group(){
 
 start_group "Download code coverage results from current run"
 gh run download "$GITHUB_RUN_ID" --name="$COVERAGE_ARTIFACT_NAME" --dir="/tmp/gh-run-download-$GITHUB_RUN_ID"
-ls /tmp/gh-run-download-$GITHUB_RUN_ID
 mv "/tmp/gh-run-download-$GITHUB_RUN_ID/$COVERAGE_FILE_NAME" $NEW_COVERAGE_PATH
 rm -r "/tmp/gh-run-download-$GITHUB_RUN_ID"
 end_group

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -80,6 +80,7 @@ end_group(){
 
 start_group "Download code coverage results from current run"
 gh run download "$GITHUB_RUN_ID" --name="$COVERAGE_ARTIFACT_NAME" --dir="/tmp/gh-run-download-$GITHUB_RUN_ID"
+ls /tmp/gh-run-download-$GITHUB_RUN_ID
 mv "/tmp/gh-run-download-$GITHUB_RUN_ID/$COVERAGE_FILE_NAME" $NEW_COVERAGE_PATH
 rm -r "/tmp/gh-run-download-$GITHUB_RUN_ID"
 end_group


### PR DESCRIPTION
- The previous technique relied on getting an arbitrary github run ID associated with a successful main branch run of unit tests. This will not work in the case where our unit tests are run under the generic `CI` pipeline.
- This PR allows main coverage artifacts to be explicitly specified so that they can be generated within the same job instead of relying on a previously run job on main merge.